### PR TITLE
collectionViewを用いた既存アプリのUI作成

### DIFF
--- a/ChatCollecthionApp.xcodeproj/xcuserdata/minato.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ChatCollecthionApp.xcodeproj/xcuserdata/minato.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "5AB0BB6B-D1B6-4D85-A436-BA7C92815CE9"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/ChatCollecthionApp/ViewController.swift
+++ b/ChatCollecthionApp/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
         Users.append(User(name: "りか", age: "20歳", imageName: "ダウンロード-1", city: "東京", comment: "こんにちは！💑こんにちは！こんにちは！こんにちは！こんにちは！こんにちは！こんにちは！"))
         Users.append(User(name: "のん", age: "18歳", imageName: "images", city: "東京", comment: "よろしく！よろしく！💑よろしく！よろしく！よろしく！よろしく！よろしく！よろしく！よろしく！"))
         Users.append(User(name: "アリー", age: "18歳", imageName: "ショート", city: "東京", comment: "こんばんは！💑こんばんは！こんばんは！こんばんは！こんばんは！こんばんは！こんばんは！こんばんは！"))
-        Users.append(User(name: "りか", age: "22歳", imageName: "笑顔", city: "埼玉", comment: "おはよう！💑おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！"))
+        Users.append(User(name: "りか", age: "22歳", imageName: "笑顔", city: "埼玉", comment: "おはよう！💑おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！おはよう！!"))
 
     }
     

--- a/ChatCollecthionApp/ViewController.swift
+++ b/ChatCollecthionApp/ViewController.swift
@@ -8,16 +8,10 @@
 import UIKit
 
 class ViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate{
-    
-    
+   
     @IBOutlet weak var mycollectionView: UICollectionView!
     
-    
-   
-//    let photos = ["ダウンロード","0913","09131","good-news","のん","りか","ぶた"]
     var Users : [User] = []
-    
-    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,36 +34,29 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
     
         func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
             return Users.count // 表示するセルの数
-          
         }
             
-            func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-               
+        func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
                 guard let cell = mycollectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as? userCollectionViewCell else {
                             fatalError("Dequeue failed: Cell.")
-                }
+           }
 
-                     cell.useNameLabel.text = Users[indexPath.row].name
-                     cell.userAgeLabel.text = Users[indexPath.row].age
-                     cell.userImageLabel.image = UIImage(named: Users[indexPath.row].imageName)
-                     cell.userCityLabel.text = Users[indexPath.row].city
-                     cell.userCommentLabel.text = Users[indexPath.row].comment
-                     
-                return cell
+           cell.useNameLabel.text = Users[indexPath.row].name
+           cell.userAgeLabel.text = Users[indexPath.row].age
+           cell.userImageLabel.image = UIImage(named: Users[indexPath.row].imageName)
+           cell.userCityLabel.text = Users[indexPath.row].city
+           cell.userCommentLabel.text = Users[indexPath.row].comment
+           return cell
 
-
-                
-
-
-            }
+        }
    
 
        func numberOfSections(in collectionView: UICollectionView) -> Int {
              return 1
          
-    }
+       }
            
 
 
 
-}
+ }

--- a/ChatCollecthionApp/userCollectionViewCell.swift
+++ b/ChatCollecthionApp/userCollectionViewCell.swift
@@ -8,21 +8,11 @@
 import UIKit
 
 class userCollectionViewCell: UICollectionViewCell {
-    
-    
-    
+   
     @IBOutlet weak var useNameLabel: UILabel!
-    
-    
     @IBOutlet weak var userAgeLabel: UILabel!
-    
-    
     @IBOutlet weak var userImageLabel: UIImageView!
-    
     @IBOutlet weak var userCityLabel: UILabel!
-
-
     @IBOutlet weak var userCommentLabel: UILabel!
-    
 
 }


### PR DESCRIPTION
## イシューのurl
https://app.zenhub.com/workspaces/jambo-5e3a5a454006fa82e247423e/issues/vjsol/jambo-server/4167
## 説明
-既存のアプリケーションであるMIYABIのトップ画面UIをcollectionViewを用いて作成しました。
## テスト項目
- シュミレーター上にてユーザーの画像、名前、年齢、所在地、自己紹介が表示されるように実装する
- 画像の崩れが内容に実装する
- 自己紹介の欄は二行で表示する
- 名前、年齢、所在地、表示を見やすく実装する。
ことを確認する
## スクリーンショット
 |  変更後  |
 | ---- |
![05fdd7e2b98348158cf7b201369c7403](https://user-images.githubusercontent.com/79615759/110740794-f8fcc900-8276-11eb-91f6-ef5c58a51878.png)
